### PR TITLE
Replace URLCNPre with URLCN in test

### DIFF
--- a/api/common/test_data.go
+++ b/api/common/test_data.go
@@ -40,7 +40,7 @@ func SetTestEnv() {
 	} else {
 		log.Println("load test data success")
 	}
-	config.SetEnv(URLCNPre, Ed.TestDataAccessID, Ed.TestDataAccessKey)
+	config.SetEnv(URLCN, Ed.TestDataAccessID, Ed.TestDataAccessKey)
 	log.Printf("test env ###### init success,Ed:%v\n", Ed)
 }
 


### PR DESCRIPTION
Replace URLCNPre, old API url, in common/test_data.go because its definition was commented out.